### PR TITLE
Adding a Django development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Vagrant
 .vagrant
+
+# Nohup
+nohup.out

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,4 +71,10 @@ Vagrant.configure("2") do |config|
   #   apt-get update
   #   apt-get install -y apache2
   # SHELL
+
+  config.vm.network(
+    "forwarded_port", guest: 8000, host: 8000, host_ip: "127.0.0.1"
+  )
+
+  config.vm.provision "shell", path: "setup.sh", privileged: false
 end


### PR DESCRIPTION
- Setup [Pipenv][1] to install and manage Django and other Python
  dependencies
- Bootstrapped an empty [Django][2] application
- Setup Vagrant to automatically bring our application up as well as
  make it accessible from a web browser

After running `vagrant up` the application can be accessed at:

> http://127.0.0.1:8000/

**Note:** Most changes had been auto-generated, only `Vagrantfile` and
`steup.sh` had been edited manually.

[1]: https://github.com/pypa/pipenv
[2]: https://www.djangoproject.com/